### PR TITLE
Remove a bit of Test.CoreLib bitrot

### DIFF
--- a/src/Test.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/Test.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -107,5 +107,13 @@ namespace System
         {
             RuntimeImports.RhpFallbackFailFast();
         }
+
+        [RuntimeExport("AppendExceptionStackFrame")]
+        private static void AppendExceptionStackFrame(object exceptionObj, IntPtr IP, int flags)
+        {
+            Exception ex = exceptionObj as Exception;
+            if (ex == null)
+                FailFast("Exceptions must derive from the System.Exception class");
+        }
     }
 }


### PR DESCRIPTION
Building with Test.CoreLib bitrotted a bit. Fixing some of that.

* Frozen string literals need to declare their dependency on
`System.String` EEType
* We need *some* `AppendExceptionStackFrame`

Two more things remaining that I'm not fixing now:

* Interop marshalling codegen insists that `System.StringBuilder` needs
to exist in the class library
* We need to make building reflection support goo optional